### PR TITLE
OZ-668: Override docker.push.registry.username from Ozone with openmrs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ local.properties
 .loadpath
 .recommenders
 settings.xml
-
+effective-pom.xml
 # External tool builders
 .externalToolBuilders/
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
+    <docker.push.registry.username>openmrs</docker.push.registry.username>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This PR is part of https://openmrs.atlassian.net/browse/HIS-3 and overrides `docker.push.registry.username` to allow publishing of bundled images to OpenMRS docker.