### PR TITLE
OZ-678: Update `ozone/` to `configs/` for serving frontend configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,8 @@ effective-pom.xml
 .idea/**/dynamic.xml
 .idea/**/uiDesigner.xml
 .idea/**/dbnavigator.xml
+.idea/.gitignore
+.idea/material_theme_project_new.xml
 
 # Gradle
 .idea/**/gradle.xml

--- a/scripts/docker-compose-override.yml
+++ b/scripts/docker-compose-override.yml
@@ -2,7 +2,7 @@ services:
 
   frontend:
     environment:
-      SPA_CONFIG_URLS: /openmrs/spa/ozone/config.json
+      SPA_CONFIG_URLS: /openmrs/spa/configs/config.json
 
   env-substitution:
     environment:


### PR DESCRIPTION
This PR updates `ozone/` to `configs/` because frontend assets/configs is now served at `/configs`. See the PR https://github.com/ozone-his/ozone-docker-compose/pull/116