### PR TITLE
HIS-19: Enable SSO & Override output filename

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,10 @@
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
     <docker.push.registry.username>openmrs</docker.push.registry.username>
+
+    <!-- Bundled Docker overrides -->
+    <bundled.docker.compose.output.filename>docker-compose.yml</bundled.docker.compose.output.filename>
+    <bundled.docker.compose.sso.enabled>true</bundled.docker.compose.sso.enabled>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Issue: https://openmrs.atlassian.net/browse/HIS-19

This PR:
- Enables SSO
- Set the final output docker compose filename to `docker-compose.yml`

Depends on:
- https://github.com/ozone-his/ozone-docker-compose/pull/164
- https://github.com/ozone-his/ozone/pull/160