### PR TITLE
Update `.gitignore` to exclude JetBrains IDE settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,8 @@ effective-pom.xml
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
+.idea
+
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml


### PR DESCRIPTION
This updates `.gitignore` to exclude JetBrains IDE settings.