### PR TITLE
HIS-19: Use `ODOO_ADDONS` env var to override Odoo addons

### DIFF
--- a/scripts/docker-compose-files.txt
+++ b/scripts/docker-compose-files.txt
@@ -4,4 +4,3 @@ docker-compose-openmrs.yml
 docker-compose-openmrs-sso.yml
 docker-compose-odoo.yml
 docker-compose-odoo-sso.yml
-docker-compose-override.yml

--- a/scripts/docker-compose-override.yml
+++ b/scripts/docker-compose-override.yml
@@ -1,4 +1,0 @@
-services:
-  odoo:
-    environment:
-      - ADDONS=sale_management,stock,account_account,purchase,mrp,mrp_product_expiry,product_expiry,l10n_generic_coa,odoo_initializer,ozone_settings,auth_oidc,auth_oauth_autologin,web_company_color

--- a/scripts/openmrs-his.env
+++ b/scripts/openmrs-his.env
@@ -2,3 +2,4 @@
 # This file is used to set environment variables for the OpenMRS HIS.
 ##
 SPA_CONFIG_URLS=/openmrs/spa/configs/ozone-frontend-config.json,/openmrs/spa/configs/openmrs-his-frontend-config.json,/openmrs/spa/configs/ozone-frontend-config-sso.json
+ODOO_ADDONS=sale_management,stock,account_account,purchase,mrp,mrp_product_expiry,product_expiry,l10n_generic_coa,odoo_initializer,web_company_color


### PR DESCRIPTION
Issue: https://openmrs.atlassian.net/browse/HIS-19

This PR gets rid of `docker-compose-override.yml` and uses `ODOO_ADDONS` environment variable to override Odoo addons. This is made possible by this [PR](https://github.com/ozone-his/ozone-docker-compose/pull/175)