### PR TITLE
HIS-19: correct `X-Forwarded-Proto` header for Keycloak reverse proxy

### DIFF
--- a/bundled-docker/proxy/default.conf.template
+++ b/bundled-docker/proxy/default.conf.template
@@ -137,7 +137,7 @@ server {
     listen 8084;
     location / {
         proxy_set_header Host $http_host;
-        proxy_set_header X-Forward-Proto http;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         set $keycloak keycloak:8080;
         proxy_pass http://$keycloak;


### PR DESCRIPTION
Issue: https://openmrs.atlassian.net/browse/HIS-19

This PR replace hardcoded 'http' value with dynamic $scheme variable in X-Forwarded-Proto header for Keycloak server block. This ensures the backend receives accurate protocol information, preventing HTTPS/HTTP mismatch issues.