### PR TITLE
HIS-45: Hardcode `SPA_CONFIGS_URLs` in the bundled Docker template re-arranging the order

### DIFF
--- a/scripts/docker-compose-bundled.yml.template
+++ b/scripts/docker-compose-bundled.yml.template
@@ -208,7 +208,7 @@ services:
     environment:
       SPA_PATH: /openmrs/spa
       API_URL: /openmrs
-      SPA_CONFIG_URLS: \${SPA_CONFIG_URLS},/openmrs/spa/configs/ozone-frontend-config-sso.json
+      SPA_CONFIG_URLS: /openmrs/spa/configs/ozone-frontend-config.json,/openmrs/spa/configs/ozone-frontend-config-sso.json,/openmrs/spa/configs/openmrs-his-frontend-config.json
       SPA_DEFAULT_LOCALE: \${SPA_DEFAULT_LOCALE}
       ODOO_PUBLIC_URL: \${SERVER_SCHEME}://\${ODOO_HOSTNAME:-localhost:8069}
       OPENMRS_PUBLIC_URL: \${SERVER_SCHEME}://\${O3_HOSTNAME:-localhost}


### PR DESCRIPTION
Issue: https://openmrs.atlassian.net/browse/HIS-45

This PR Hardcodes `SPA_CONFIGS_URLs` in the bundled Docker template re-arranging the order