### PR TITLE
HIS-19: Remove `web` Docker network

### DIFF
--- a/scripts/docker-compose-bundled.yml.template
+++ b/scripts/docker-compose-bundled.yml.template
@@ -1,6 +1,5 @@
 networks:
   ozone:
-  web:
 
 services:
   mysql:
@@ -108,7 +107,6 @@ services:
       traefik.http.middlewares.limit.buffering.maxRequestBodyBytes: 20971520
     networks:
       - ozone
-      - web
     restart: unless-stopped
     volumes:
       - "\${ODOO_FILESTORE:-odoo-filestore}:/var/lib/odoo/filestore"
@@ -184,7 +182,6 @@ services:
       traefik.http.routers.fhir-erp.entrypoints: "websecure"
       traefik.http.services.fhir-erp.loadbalancer.server.port: 8080
     networks:
-      web:
       ozone:
         aliases:
           - fhir-erp
@@ -227,7 +224,6 @@ services:
       traefik.http.middlewares.openmrs-spa-redirectregex.redirectregex.replacement: https://\${O3_HOSTNAME}/openmrs/spa/home
     networks:
       - ozone
-      - web
     restart: unless-stopped
     volumes:
       - "openmrs-data:/openmrs/data"
@@ -272,7 +268,6 @@ services:
       traefik.http.middlewares.gzip.compress: true
     networks:
       - ozone
-      - web
     restart: unless-stopped
 
   keycloak:
@@ -332,7 +327,6 @@ services:
         condition: service_started
     networks:
       ozone:
-      web:
     labels:
       traefik.enable: "true"
       traefik.http.routers.keycloak.rule: "Host(`\${KEYCLOAK_HOSTNAME}`)"
@@ -347,6 +341,8 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost/"]
     networks:
       ozone:
+        aliases:
+          - ozone-proxy
     ports:
       - "8080:80"
       - "8069:8069"


### PR DESCRIPTION
This PR attempts to fix the issue where some services drops connection to the database by having one network `ozone`.